### PR TITLE
Allowed Headless UI testing with chromium from Alpine on OIDC mock

### DIFF
--- a/references/oidc-mock/test/integration/features/step_definitions/ui.js
+++ b/references/oidc-mock/test/integration/features/step_definitions/ui.js
@@ -29,7 +29,7 @@ const scope = 'openid email address'
 Given('I navigate to the authorize page', async function() {
   this.browser = await puppeteer.launch({
     ignoreHTTPSErrors: true,
-    headless:false,
+    headless: true,
     args: ["--no-sandbox"]
   })
   this.page = await this.browser.newPage()

--- a/tools/pipeline-runner/Dockerfile
+++ b/tools/pipeline-runner/Dockerfile
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:alpine
+FROM golang:alpine3.12
 
 # Install our tools
 RUN apk add --no-cache \
-  curl=7.69.1-r1 \
+  curl=7.69.1-r2 \
   docker=19.03.12-r0 \
   git=2.26.2-r0 \
   jq=1.6-r1 \
@@ -24,10 +24,23 @@ RUN apk add --no-cache \
   nodejs=12.18.4-r0 \
   npm=12.18.4-r0 \
   openjdk11-jre-headless=11.0.9_p11-r0 \
-  util-linux=2.35.2-r0
+  util-linux=2.35.2-r0 \
+  # add chromium and dependencies for UI testing
+  chromium \
+  nss \
+  freetype \
+  freetype-dev \
+  harfbuzz \
+  ca-certificates \
+  ttf-freefont
 
 RUN go get github.com/google/addlicense
 RUN export GO111MODULE=on && go get github.com/googlecodelabs/tools/claat@v2.2.0
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
+RUN npm install --global puppeteer@5.2.1
 
 # install our dependencies
 COPY *.sh /usr/bin/

--- a/tools/pipeline-runner/Dockerfile
+++ b/tools/pipeline-runner/Dockerfile
@@ -26,13 +26,13 @@ RUN apk add --no-cache \
   openjdk11-jre-headless=11.0.9_p11-r0 \
   util-linux=2.35.2-r0 \
   # add chromium and dependencies for UI testing
-  chromium \
-  nss \
-  freetype \
-  freetype-dev \
-  harfbuzz \
-  ca-certificates \
-  ttf-freefont
+  chromium=86.0.4240.111-r0 \
+  nss=3.59-r0 \
+  freetype=2.10.4-r0 \
+  freetype-dev=2.10.4-r0 \
+  harfbuzz=2.6.6-r0 \
+  ca-certificates=20191127-r4 \
+  ttf-freefont=20120503-r1
 
 RUN go get github.com/google/addlicense
 RUN export GO111MODULE=on && go get github.com/googlecodelabs/tools/claat@v2.2.0


### PR DESCRIPTION
What's changed, or what was fixed?

- added chromium and dependencies to pipeline-runner
- set oidc-mock tests to be headless

- [ ] I have run all the tests locally and they all pass.
- [ ] I have followed the relevant style guide for my changes.
